### PR TITLE
Some modifications to make the scripts work on IDA 6.1, and a few other ...

### DIFF
--- a/base/function.py
+++ b/base/function.py
@@ -130,6 +130,10 @@ def contains(fn, ea):
         continue
     return False
 
+def within(ea):
+    '''Returns True if address is associated with a function of some kind'''
+    return idaapi.get_func(ea) is not None
+
 def top(fn):
     '''Return the top of the specified function'''
     min,_ = getRange(fn)

--- a/misc/helper.py
+++ b/misc/helper.py
@@ -20,7 +20,7 @@ class remote(object):
     def go(self, ea):
         database.go( self.get(ea) )
 
-import idaapi,sip
+import idaapi
 class InputBox(idaapi.PluginForm):
     def OnCreate(self, form):
         self.parent = self.FormToPyQtWidget(form)
@@ -38,7 +38,11 @@ class InputBox(idaapi.PluginForm):
 ### another item menu to toolbar
 ### find the QAction associated with a command (or keypress)
 
-import PySide.QtGui,idaapi
+try:
+    import PySide.QtGui
+except ImportError:
+    logging.warn("__module__:%s:Unable to load PySide.QtGui module. Certain UI.* methods might not work.", __name__)
+
 class UI(object):
     '''static class for interacting with IDA's Qt user-interface'''
     @classmethod
@@ -266,3 +270,13 @@ def checkmarks():
         print >>sys.stdout, '%x : in function %s'% (k,function.name(function.byAddress(k)))
         print >>sys.stdout, '\n'.join( ('- %x : %s'%(a,m) for a,m in sorted(v)) )
     return
+
+def above(ea):
+    '''Display all the callers of the function at /ea/'''
+    tryhard = lambda x: '%s+%x'%(database.name(function.top(x)),x-function.top(x)) if function.within(x) else hex(x) if database.name(x) is None else database.name(x)
+    return '\n'.join(map(tryhard,function.up(ea)))
+
+def below(ea):
+    '''Display all the functions that the function at /ea/ can call'''
+    tryhard = lambda x: '%s+%x'%(database.name(function.top(x)),x-function.top(x)) if function.within(x) else hex(x) if database.name(x) is None else database.name(x)
+    return '\n'.join(map(tryhard,function.down(ea)))


### PR DESCRIPTION
...changes.

base/database:
    moved functionality for next\* and prev\* into a class called address
    moved xref code (*up, *down) into a class called xref
        added the ability to add/remove code refs and data refs
    replace some usage of idc with idaapi
    modified path(), idb(), and module() to use os.path to figure things out
    modified go(...) to call idaapi.jumpto regardless of the address being valid or not.
        displays a warning if the address is known to be bad.
    implemented database.byBytes, database.byRegex for searching
    added database.iterate_search for iterating through all results of byBytes and byRegex

base/segment:
    added support to segment.create for specifying the origin during 16-bit segment creation
        also added support for failing if a segment already exists with the specified name
    segment.delete will by default only remove the segment metadata instead of both the metadata and the content

base/function:
    added function.within for determining if an address is associated with a function chunk.

misc/helper:
    Removed an unnecessary reference to a 'sip' module. (?)
    Made the PySides module import non-mandatory
    added above and below for returning a function's callers and callees in a printable form
